### PR TITLE
Added "System." namespace prefix before "Convert.ToString()"

### DIFF
--- a/src/System.Web.NHaml/Compilers/CodeDomClassBuilder.cs
+++ b/src/System.Web.NHaml/Compilers/CodeDomClassBuilder.cs
@@ -189,7 +189,7 @@ namespace System.Web.NHaml.Compilers
                             .WithInvokePrimitiveParameter(nodeVariableName);
                     else
                     {
-                        parameter = CodeDomFluentBuilder.GetCodeMethodInvokeExpression("ToString", "Convert")
+                        parameter = CodeDomFluentBuilder.GetCodeMethodInvokeExpression("ToString", "System.Convert")
                             .WithCodeSnippetParameter(nodeVariableName);
                     }
                 }

--- a/src/System.Web.NHaml/Compilers/CodeDomFluentBuilder.cs
+++ b/src/System.Web.NHaml/Compilers/CodeDomFluentBuilder.cs
@@ -49,8 +49,8 @@ namespace System.Web.NHaml.Compilers
         public static CodeMethodInvokeExpression WithInvokeCodeSnippetToStringParameter(this CodeMethodInvokeExpression expression,
             string codeSnippet)
         {
-            return WithParameter(expression, 
-                GetCodeMethodInvokeExpression("ToString", "Convert").WithCodeSnippetParameter(codeSnippet));
+            return WithParameter(expression,
+                GetCodeMethodInvokeExpression("ToString", "System.Convert").WithCodeSnippetParameter(codeSnippet));
         }
 
         public static CodeMethodInvokeExpression WithCodeSnippetParameter(this CodeMethodInvokeExpression expression,

--- a/tests/System.Web.NHaml.Tests/Compilers/CodeDomClassBuilder_Tests.cs
+++ b/tests/System.Web.NHaml.Tests/Compilers/CodeDomClassBuilder_Tests.cs
@@ -78,7 +78,7 @@ namespace NHaml.Tests.Compilers
             classBuilder.AppendCodeToString("1+1");
             string result = classBuilder.Build(ClassName);
 
-            Assert.That(result, Is.StringContaining("textWriter.Write(Convert.ToString(1+1));"));
+            Assert.That(result, Is.StringContaining("textWriter.Write(System.Convert.ToString(1+1));"));
         }
 
         [Test]
@@ -148,7 +148,7 @@ namespace NHaml.Tests.Compilers
                                      };
             classBuilder.AppendAttributeNameValuePair("Name", valueFragments, '\"');
             string result = classBuilder.Build(ClassName);
-            Assert.That(result, Is.StringContaining(".Append(Convert.ToString(Model.Property));"));
+            Assert.That(result, Is.StringContaining(".Append(System.Convert.ToString(Model.Property));"));
         }
 
         [Test]


### PR DESCRIPTION
Because it may conflict with "Convert" root namespace of the project which uses the template engine.
